### PR TITLE
Now copies black_dragon.png to the location passed as the cmdline arg…

### DIFF
--- a/set_colors.py
+++ b/set_colors.py
@@ -65,11 +65,11 @@ if __name__ == "__main__":
     tool = xmldoc.getElementsByTagName("TOOL")[0]
     tool.setAttribute("TOOL_NAME", "CodeBrowserDarkNight")
 
-    dragon_path = expanduser("~") + "/.ghidra/.ghidra-9.0/tools/black_dragon.png"
+    dragon_path = "/".join(sys.argv[1].split("/")[:-1]) + "/black_dragon.png"
     icon = xmldoc.getElementsByTagName("ICON")[0]
-    icon.setAttribute("LOCATION", dragon_path)
-    copyfile("black_dragon.png", dragon_path)
     print("-> black dragon icon to %s" % dragon_path)
+    copyfile("black_dragon.png", dragon_path)
+    icon.setAttribute("LOCATION", dragon_path)
 
     d = os.path.dirname(sys.argv[1])
 


### PR DESCRIPTION
… instead to an hard-coded one.

Similar to @shoaloak 's request, except mine's work with any given path whereas his version works only if the path has structure similar to "~/.ghidra/.ghidra_{version}/tools/{file}".

Also, I've changed the order of the statements so that shutil.copyfile actually comes before the function using the file copied (which is more logical).

Please, don't abandon this repository without checking all pull requests since they are will really make sure this script works in all future versions of Ghidra and on Windows.

Thanks you for the theme and stay safe.